### PR TITLE
fix windows detection macro in framework header

### DIFF
--- a/include/vku/vku_framework.hpp
+++ b/include/vku/vku_framework.hpp
@@ -11,7 +11,7 @@
 #ifndef VKU_FRAMEWORK_HPP
 #define VKU_FRAMEWORK_HPP
 
-#ifdef WIN32
+#ifdef _WIN32
 #define VK_USE_PLATFORM_WIN32_KHR
 #define GLFW_EXPOSE_NATIVE_WIN32
 #define VKU_SURFACE "VK_KHR_win32_surface"


### PR DESCRIPTION
the PR fixes a missing underscore prefix for the windows detection macro.
Also see table of windows macros defined in msvc: https://msdn.microsoft.com/en-us/library/b0084kay.aspx search for _win32

I am not sure, if WIN32 is defined by CMake, but without CMake, it is definitely not defined.