### PR TITLE
Fix surface destruction in framework

### DIFF
--- a/include/vku/vku_framework.hpp
+++ b/include/vku/vku_framework.hpp
@@ -291,7 +291,7 @@ public:
   }
 
   void init(const vk::Instance &instance, const vk::Device &device, const vk::PhysicalDevice &physicalDevice, uint32_t graphicsQueueFamilyIndex, vk::SurfaceKHR surface) {
-    surface_ = vk::UniqueSurfaceKHR(surface);
+    surface_ = vk::UniqueSurfaceKHR(surface, vk::SurfaceKHRDeleter{ instance });
     device_ = device;
     presentQueueFamily_ = 0;
     auto &pd = physicalDevice;


### PR DESCRIPTION
Hi,
I have another PR.

UniqueSurface in the window class uses a SurfaceDeleter with a default parameter for the instance.
The default paramater for the instance is NULL.
Given this, SurfaceDeleter destroys the given surface handle with a NULL interface Handle.
Therefore, the surface is not correctly destroyed e.g. in the window destructor, which can lead to a memory leak or an exception/program crash (e.g. msvc debug mode).