### PR TITLE
fix uninitialized variable

### DIFF
--- a/include/vku/vku.hpp
+++ b/include/vku/vku.hpp
@@ -541,7 +541,7 @@ private:
   struct State {
     std::vector<uint32_t> opcodes_;
     vk::UniqueShaderModule module_;
-    bool ok_;
+    bool ok_ = false;
   };
 
   State s;

--- a/include/vku/vku_framework.hpp
+++ b/include/vku/vku_framework.hpp
@@ -640,7 +640,7 @@ private:
   vk::Format swapchainImageFormat_ = vk::Format::eB8G8R8A8Unorm;
   vk::ColorSpaceKHR swapchainColorSpace_ = vk::ColorSpaceKHR::eSrgbNonlinear;
   vk::Device device_;
-  bool ok_;
+  bool ok_ = false;
 };
 
 } // namespace vku


### PR DESCRIPTION
If the constructor (init function),
an object will be created but `ok_` is not guaranteed to be false.
This leads that i.e. the `window::ok()` method may give a non correct output.

Btw:
Is there a reason, why you are using a init method instead of constructor delegation for the window class?
If not, I may rewrite the constructors in such a way, that the initializer expression can be used (which removes a potential unnecessary init of some objects).