### PR TITLE
Fix for MacOS when no window for visualization is needed.

### DIFF
--- a/include/vku/vku.hpp
+++ b/include/vku/vku.hpp
@@ -314,7 +314,7 @@ public:
       instance_extensions_.push_back(VKU_SURFACE);
     #endif
     instance_extensions_.push_back("VK_KHR_surface");
-#ifdef __APPLE__
+#if defined( __APPLE__ ) && defined(VK_EXT_METAL_SURFACE_EXTENSION_NAME)
     instance_extensions_.push_back(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
 #endif //__APPLE__
     return *this;


### PR DESCRIPTION
I had not tested the helloCompute example and it will not compile on Mac OS before this fix.
All other examples will compile and run.
With this fix, the helloCompute does compile and run.