### PR TITLE
Remove semantically useless const qualifiers on returns and fix examples with the cleanup.

### DIFF
--- a/examples/helloTriangle/helloTriangle.cpp
+++ b/examples/helloTriangle/helloTriangle.cpp
@@ -78,7 +78,7 @@ int main() {
 
           // Create a pipeline using a renderPass built for our window.
           auto renderPass = window.renderPass();
-          auto &cache = fw.pipelineCache();
+          auto cache = fw.pipelineCache();
 
           return pm.createUnique(device, cache, *pipelineLayout_, renderPass);
         };

--- a/examples/pushConstants/pushConstants.cpp
+++ b/examples/pushConstants/pushConstants.cpp
@@ -93,7 +93,7 @@ int main() {
 
       // Create a pipeline using a renderPass built for our window.
       auto renderPass = window.renderPass();
-      auto &cache = fw.pipelineCache();
+      auto cache = fw.pipelineCache();
       return pm.createUnique(device, cache, *pipelineLayout_, renderPass);
     };
     auto pipeline = buildPipeline();

--- a/examples/teapot/teapot.cpp
+++ b/examples/teapot/teapot.cpp
@@ -157,7 +157,7 @@ int main() {
 	auto pm = buildCameraPipeline();
 
     auto renderPass = window.renderPass();
-    auto &cache = fw.pipelineCache();
+    auto cache = fw.pipelineCache();
     auto finalPipeline = pm.createUnique(device, cache, *pipelineLayout, renderPass);
 
     ////////////////////////////////////////

--- a/examples/texture/texture.cpp
+++ b/examples/texture/texture.cpp
@@ -70,7 +70,7 @@ int main() {
     pm.vertexAttribute(1, 0, vk::Format::eR32G32B32Sfloat, (uint32_t)offsetof(Vertex, colour));
 
     auto renderPass = window.renderPass();
-    auto &cache = fw.pipelineCache();
+    auto cache = fw.pipelineCache();
     return  pm.createUnique(device, cache, *pipelineLayout, renderPass);
   };
 

--- a/examples/uniforms/uniforms.cpp
+++ b/examples/uniforms/uniforms.cpp
@@ -98,7 +98,7 @@ int main() {
 
       // Create a pipeline using a renderPass built for our window.
       auto renderPass = window.renderPass();
-      auto &cache = fw.pipelineCache();
+      auto cache = fw.pipelineCache();
       return pm.createUnique(device, cache, *pipelineLayout_, renderPass);
     };
     auto pipeline = buildPipeline();

--- a/include/vku/vku_framework.hpp
+++ b/include/vku/vku_framework.hpp
@@ -142,25 +142,25 @@ public:
   }
 
   /// Get the Vulkan instance.
-  const vk::Instance instance() const { return *instance_; }
+  vk::Instance instance() const { return *instance_; }
 
   /// Get the Vulkan device.
-  const vk::Device device() const { return *device_; }
+  vk::Device device() const { return *device_; }
 
   /// Get the queue used to submit graphics jobs
-  const vk::Queue graphicsQueue() const { return device_->getQueue(graphicsQueueFamilyIndex_, 0); }
+  vk::Queue graphicsQueue() const { return device_->getQueue(graphicsQueueFamilyIndex_, 0); }
 
   /// Get the queue used to submit compute jobs
-  const vk::Queue computeQueue() const { return device_->getQueue(computeQueueFamilyIndex_, 0); }
+  vk::Queue computeQueue() const { return device_->getQueue(computeQueueFamilyIndex_, 0); }
 
   /// Get the physical device.
   const vk::PhysicalDevice &physicalDevice() const { return physical_device_; }
 
   /// Get the default pipeline cache (you can use your own if you like).
-  const vk::PipelineCache pipelineCache() const { return *pipelineCache_; }
+  vk::PipelineCache pipelineCache() const { return *pipelineCache_; }
 
   /// Get the default descriptor pool (you can use your own if you like).
-  const vk::DescriptorPool descriptorPool() const { return *descriptorPool_; }
+  vk::DescriptorPool descriptorPool() const { return *descriptorPool_; }
 
   /// Get the family index for the graphics queues.
   uint32_t graphicsQueueFamilyIndex() const { return graphicsQueueFamilyIndex_; }
@@ -455,7 +455,7 @@ public:
   uint32_t presentQueueFamily() const { return presentQueueFamily_; }
 
   /// Get the queue used to submit graphics jobs
-  const vk::Queue presentQueue() const { return device_.getQueue(presentQueueFamily_, 0); }
+  vk::Queue presentQueue() const { return device_.getQueue(presentQueueFamily_, 0); }
 
   /// Return true if this window was created sucessfully.
   bool ok() const { return ok_; }
@@ -492,7 +492,7 @@ public:
   vk::ColorSpaceKHR swapchainColorSpace() const { return swapchainColorSpace_; }
 
   /// Return the swapchain object
-  const vk::SwapchainKHR swapchain() const { return *swapchain_; }
+  vk::SwapchainKHR swapchain() const { return *swapchain_; }
 
   /// Return the views of the swap chain images
   const std::vector<vk::ImageView> &imageViews() const { return imageViews_; }


### PR DESCRIPTION
This should be an easy pull request. It's a simple series of clang-tidy flagged cleanups. They do create a strange issue with the examples, but it is because the examples had a confusing `auto &` where it should have been either `const auto &` or `auto`. All such instances have been addressed.