### PR TITLE
Shader specialization

### DIFF
--- a/examples/teapot/teapot.cpp
+++ b/examples/teapot/teapot.cpp
@@ -123,25 +123,17 @@ int main() {
     //
     // Build the final pipeline including enabling the depth test
 
-
-//    vku::PipelineMaker pm{window.width(), window.height()};
-//    pm.shader(vk::ShaderStageFlagBits::eVertex, final_vert);
-//    pm.shader(vk::ShaderStageFlagBits::eFragment, final_frag);
-//    pm.vertexBinding(0, (uint32_t)sizeof(Vertex));
-//    pm.vertexAttribute(0, 0, vk::Format::eR32G32B32Sfloat, (uint32_t)offsetof(Vertex, pos));
-//    pm.vertexAttribute(1, 0, vk::Format::eR32G32B32Sfloat, (uint32_t)offsetof(Vertex, normal));
-//    pm.vertexAttribute(2, 0, vk::Format::eR32G32Sfloat, (uint32_t)offsetof(Vertex, uv));
-//    pm.depthTestEnable(VK_TRUE);
-//    pm.cullMode(vk::CullModeFlagBits::eBack);
-//    pm.frontFace(vk::FrontFace::eCounterClockwise);
-
 		vku::ShaderModule final_vert{window.device(), BINARY_DIR "teapot.vert.spv"};
 		vku::ShaderModule final_frag{window.device(), BINARY_DIR "teapot.frag.spv"};
 	auto buildCameraPipeline = [&]() {
 		{
 
 			vku::PipelineMaker pm{window.width(), window.height()};
-			pm.shader(vk::ShaderStageFlagBits::eVertex, final_vert, {{0,3}});
+			pm.shader(vk::ShaderStageFlagBits::eVertex, final_vert, {
+                                                                                    {0,2},
+                                                                                    {1, 0.5f },
+                                                                                    {3, true }
+                                                                                });
 			pm.shader(vk::ShaderStageFlagBits::eFragment, final_frag);
 			pm.vertexBinding(0, (uint32_t)sizeof(Vertex));
 			pm.vertexAttribute(0, 0, vk::Format::eR32G32B32Sfloat, (uint32_t)offsetof(Vertex, pos));

--- a/examples/teapot/teapot.cpp
+++ b/examples/teapot/teapot.cpp
@@ -1,4 +1,4 @@
-
+#include <cstdlib>
 #include <vku/vku_framework.hpp>
 #include <vku/vku.hpp>
 #include <glm/glm.hpp>
@@ -12,7 +12,30 @@
 #include <gilgamesh/encoders/fbx_encoder.hpp>
 struct Vertex { glm::vec3 pos; glm::vec3 normal; glm::vec2 uv; };
 
-int main() {
+// Compilation constant values.
+bool useIntFactor = false;
+float floatFactor = 1.0;
+int intFactor = 1;
+
+void usage(char *cmd)
+{
+  std::cerr << "Usage: " << cmd << " [ -f <floatScale> | -i <intScale> ]" << std::endl;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc != 1 && argc != 3)
+    usage(argv[0]);
+  if (argc == 3) {
+    if( argv[1] == std::string{"-f"} ) {
+      floatFactor = std::atof(argv[2]);
+      useIntFactor = false;
+    } else if (argv[1] == std::string{"-i"}) {
+      useIntFactor = true;
+      intFactor = std::atoi(argv[2]);
+    } else
+      usage(argv[0]);
+  }
+
   glfwInit();
 
   glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
@@ -125,28 +148,38 @@ int main() {
 
 		vku::ShaderModule final_vert{window.device(), BINARY_DIR "teapot.vert.spv"};
 		vku::ShaderModule final_frag{window.device(), BINARY_DIR "teapot.frag.spv"};
-	auto buildCameraPipeline = [&]() {
-		{
+                auto buildCameraPipeline = [&]() {
+                  {
 
-			vku::PipelineMaker pm{window.width(), window.height()};
-			pm.shader(vk::ShaderStageFlagBits::eVertex, final_vert, {
-                                                                                    {0,2},
-                                                                                    {1, 0.5f },
-                                                                                    {3, true }
-                                                                                });
-			pm.shader(vk::ShaderStageFlagBits::eFragment, final_frag);
-			pm.vertexBinding(0, (uint32_t)sizeof(Vertex));
-			pm.vertexAttribute(0, 0, vk::Format::eR32G32B32Sfloat, (uint32_t)offsetof(Vertex, pos));
-			pm.vertexAttribute(1, 0, vk::Format::eR32G32B32Sfloat, (uint32_t)offsetof(Vertex, normal));
-			pm.vertexAttribute(2, 0, vk::Format::eR32G32Sfloat, (uint32_t)offsetof(Vertex, uv));
-			pm.depthTestEnable(VK_TRUE);
-			pm.cullMode(vk::CullModeFlagBits::eBack);
-			pm.frontFace(vk::FrontFace::eCounterClockwise);
-			return pm;
-		}
-	};
+                    vku::PipelineMaker pm{window.width(), window.height()};
+                    std::vector<vku::SpecConst> specList{
+                        {0, intFactor},
+                        {1, floatFactor},
+                        {3, useIntFactor}
+                    };
+                    pm.shader(vk::ShaderStageFlagBits::eVertex, final_vert,
+                              specList);
+                    //pm.shader(vk::ShaderStageFlagBits::eVertex, final_vert, {
+                    //                {0,2},
+                    //                {1, 0.5f },
+                    //                {3, false }
+                    //            });
+                    pm.shader(vk::ShaderStageFlagBits::eFragment, final_frag);
+                    pm.vertexBinding(0, (uint32_t)sizeof(Vertex));
+                    pm.vertexAttribute(0, 0, vk::Format::eR32G32B32Sfloat,
+                                       (uint32_t)offsetof(Vertex, pos));
+                    pm.vertexAttribute(1, 0, vk::Format::eR32G32B32Sfloat,
+                                       (uint32_t)offsetof(Vertex, normal));
+                    pm.vertexAttribute(2, 0, vk::Format::eR32G32Sfloat,
+                                       (uint32_t)offsetof(Vertex, uv));
+                    pm.depthTestEnable(VK_TRUE);
+                    pm.cullMode(vk::CullModeFlagBits::eBack);
+                    pm.frontFace(vk::FrontFace::eCounterClockwise);
+                    return pm;
+                  }
+                };
 
-	auto pm = buildCameraPipeline();
+                auto pm = buildCameraPipeline();
 
     auto renderPass = window.renderPass();
     auto cache = fw.pipelineCache();

--- a/examples/teapot/teapot.vert
+++ b/examples/teapot/teapot.vert
@@ -1,5 +1,7 @@
 #version 450
 layout (constant_id = 0) const int xF = 1;
+layout (constant_id = 1) const float fX = 1;
+layout (constant_id = 3) const bool isScaled = false;
 layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec3 inNormal;
 layout(location = 2) in vec2 inUv;
@@ -26,7 +28,7 @@ out gl_PerVertex {
 void main() {
   // Get position in camera, light and world space.
   gl_Position = u.modelToPerspective * vec4(inPosition.xyz, 1.0);
-  gl_Position.x *= xF;
+  gl_Position.x *= isScaled ? 1.0f*xF : fX;
   vec4 lightSpacePos = u.modelToLight * vec4(inPosition.xyz, 1.0);
   vec3 worldPos = (u.modelToWorld * vec4(inPosition.xyz, 1.0)).xyz;
 

--- a/examples/teapot/teapot.vert
+++ b/examples/teapot/teapot.vert
@@ -1,7 +1,7 @@
 #version 450
-layout (constant_id = 0) const int xF = 1;
-layout (constant_id = 1) const float fX = 1;
-layout (constant_id = 3) const bool isScaled = false;
+layout (constant_id = 0) const int intFactor = 1;
+layout (constant_id = 1) const float floatFactor = 1;
+layout (constant_id = 3) const bool useIntFactor = false;
 layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec3 inNormal;
 layout(location = 2) in vec2 inUv;
@@ -28,7 +28,7 @@ out gl_PerVertex {
 void main() {
   // Get position in camera, light and world space.
   gl_Position = u.modelToPerspective * vec4(inPosition.xyz, 1.0);
-  gl_Position.x *= isScaled ? 1.0f*xF : fX;
+  gl_Position.x *= useIntFactor ? 1.0f*intFactor : floatFactor;
   vec4 lightSpacePos = u.modelToLight * vec4(inPosition.xyz, 1.0);
   vec3 worldPos = (u.modelToWorld * vec4(inPosition.xyz, 1.0)).xyz;
 


### PR DESCRIPTION
This PR adds general constant specialization with demo of bool, int and float.
Use `05-teapot -i <xFactor>` to set a bool to true, and an integer constant to `xFactor`;
use  `05-teapot -f <xFactor>` to set the bool to false and a float constant to `xFactor`.
The x coordinate is scaled by xFactor.

The syntax accepts an initializer list or a vector of `SpecConst` which is `{ id, value }`, where value can be any type accepted by Vulkan (tested with `int_32`, `uint_32`, `bool` and `float`). It should accept `double` as well, but I do not have a card/driver accepting doubles at the moment.