### PR TITLE
vku::VertexBuffer: add vk::BufferUsageFlagBits::eTransferDst to fix validation error

### DIFF
--- a/include/vku/vku.hpp
+++ b/include/vku/vku.hpp
@@ -1271,7 +1271,7 @@ public:
   VertexBuffer() {
   }
 
-  VertexBuffer(const vk::Device &device, const vk::PhysicalDeviceMemoryProperties &memprops, size_t size) : GenericBuffer(device, memprops, vk::BufferUsageFlagBits::eVertexBuffer, size, vk::MemoryPropertyFlagBits::eDeviceLocal) {
+  VertexBuffer(const vk::Device &device, const vk::PhysicalDeviceMemoryProperties &memprops, size_t size) : GenericBuffer(device, memprops, vk::BufferUsageFlagBits::eVertexBuffer | vk::BufferUsageFlagBits::eTransferDst, size, vk::MemoryPropertyFlagBits::eDeviceLocal) {
   }
 };
 


### PR DESCRIPTION
When using `vku::VertexBuffer::upload` I get the following Vulkan validation message at runtime:

`VUID-vkCmdCopyBuffer-dstBuffer-00120(ERROR / SPEC): msgNum: 1355715885 - Validation Error: [ VUID-vkCmdCopyBuffer-dstBuffer-00120 ] Object 0: handle = 0x6dc7200000000005, type = VK_OBJECT_TYPE_BUFFER; | MessageID = 0x50ce952d | Invalid usage flag for VkBuffer 0x6dc7200000000005[] used by vkCmdCopyBuffer(). In this case, VkBuffer should have VK_BUFFER_USAGE_TRANSFER_DST_BIT set during creation. The Vulkan spec states: dstBuffer must have been created with VK_BUFFER_USAGE_TRANSFER_DST_BIT usage flag (https://vulkan.lunarg.com/doc/view/1.2.170.0/windows/1.2-extensions/vkspec.html#VUID-vkCmdCopyBuffer-dstBuffer-00120)`

I think this is due to the fact that the `GenericBuffer` base is created without setting the `vk::BufferUsageFlagBits::eTransferDst` flag. Hence this PR.

Thanks a lot for this library!