### PR TITLE
vku::IndexBuffer: added vk::BufferUsageFlagBits::eTransferDst to fix validation error

### DIFF
--- a/include/vku/vku.hpp
+++ b/include/vku/vku.hpp
@@ -1294,7 +1294,7 @@ public:
   IndexBuffer() {
   }
 
-  IndexBuffer(const vk::Device &device, const vk::PhysicalDeviceMemoryProperties &memprops, vk::DeviceSize size) : GenericBuffer(device, memprops, vk::BufferUsageFlagBits::eIndexBuffer, size, vk::MemoryPropertyFlagBits::eDeviceLocal) {
+  IndexBuffer(const vk::Device &device, const vk::PhysicalDeviceMemoryProperties &memprops, vk::DeviceSize size) : GenericBuffer(device, memprops, vk::BufferUsageFlagBits::eIndexBuffer | vk::BufferUsageFlagBits::eTransferDst, size, vk::MemoryPropertyFlagBits::eDeviceLocal) {
   }
 };
 


### PR DESCRIPTION
Sorry, just occurred to me that `IndexBuffer` might have the same issue (only used `HostIndexBuffer` so far.

So, same situation:  missing flag `vk::BufferUsageFlagBits::eTransferDst` causes validation error when uploading data.