### PR TITLE
Checking for not-good will also catch an absent file.

### DIFF
--- a/include/vku/vku.hpp
+++ b/include/vku/vku.hpp
@@ -618,7 +618,7 @@ public:
   /// Construct a shader module from a file
   ShaderModule(const vk::Device &device, const std::string &filename) {
     auto file = std::ifstream(filename, std::ios::binary);
-    if (file.bad()) {
+    if (!file.good()) {
       return;
     }
 


### PR DESCRIPTION
`ifstream::bad` will still return `false` when a file is missing. (It took me a few minutes to notice that, while I was working on something.) I thought a check using `ifstream::good` might be helpful.