### PR TITLE
Fix examples to compile in MSVC

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(${PROJECT_SOURCE_DIR}/../include)
 add_definitions(-DSOURCE_DIR="${CMAKE_SOURCE_DIR}/")
 add_definitions(-DBINARY_DIR="${PROJECT_BINARY_DIR}/")
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 
 if (${CMAKE_VERSION} VERSION_LESS "3.7.0")
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../cmake")

--- a/examples/crystalLogo/crystalLogo.cpp
+++ b/examples/crystalLogo/crystalLogo.cpp
@@ -65,11 +65,11 @@ int main() {
   auto device = fw.device();
 
   vku::Window window{
-    .instance = fw.instance(),
-    .device = device,
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    device,
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;
@@ -86,12 +86,12 @@ int main() {
   // flip viewport to match opengl ( +x > Right, +y ^ UP, +z towards viewer from screen ), instead of vulkan default
   // also requires pipeline set with cullMode:BACK and frontFace:CounterClockWise
   auto viewport = vk::Viewport{
-    .x = 0.0f,                                     //Vulkan default:0
-    .y = static_cast<float>(window.height()),      //Vulkan default:0
-    .width = static_cast<float>(window.width()),   //Vulkan default:width
-    .height = -static_cast<float>(window.height()),//Vulkan default:height
-    .minDepth = 0.5f,                              //Vulkan default:0
-    .maxDepth = 1.0f                               //Vulkan default:1
+    0.0f,                                     //Vulkan default:0
+    static_cast<float>(window.height()),      //Vulkan default:0
+    static_cast<float>(window.width()),   //Vulkan default:width
+    -static_cast<float>(window.height()),//Vulkan default:height
+    0.5f,                              //Vulkan default:0
+    1.0f                               //Vulkan default:1
   };
 
   ////////////////////////////////////////
@@ -579,11 +579,11 @@ int main() {
   
     // Begin rendering using the framebuffer and renderpass
     displacementRpbi = vk::RenderPassBeginInfo {
-      .renderPass = *displacementRenderPass,
-      .framebuffer = *displacementFrameBuffer,
-      .renderArea = vk::Rect2D{{0, 0}, {window.width(), window.height()}},
-      .clearValueCount = (uint32_t) clearColours.size(),
-      .pClearValues = clearColours.data()
+      *displacementRenderPass,
+      *displacementFrameBuffer,
+      vk::Rect2D{{0, 0}, {window.width(), window.height()}},
+      (uint32_t) clearColours.size(),
+      clearColours.data()
     };
   
     // Build the renderpass 
@@ -610,11 +610,11 @@ int main() {
   
     // Begin rendering using the framebuffer and renderpass
     maskRpbi = vk::RenderPassBeginInfo{
-      .renderPass = *maskRenderPass,
-      .framebuffer = *maskFrameBuffer,
-      .renderArea = vk::Rect2D{{0, 0}, {window.width(), window.height()}},
-      .clearValueCount = (uint32_t) clearColoursMask.size(),
-      .pClearValues = clearColoursMask.data()
+      *maskRenderPass,
+      *maskFrameBuffer,
+      vk::Rect2D{{0, 0}, {window.width(), window.height()}},
+      (uint32_t) clearColoursMask.size(),
+      clearColoursMask.data()
     };
   }
 
@@ -747,11 +747,11 @@ int main() {
   
     // Begin rendering using the framebuffer and renderpass
     contentRpbi = vk::RenderPassBeginInfo{
-      .renderPass = *contentRenderPass,
-      .framebuffer = *contentFrameBuffer,
-      .renderArea = vk::Rect2D{{0, 0}, {window.width(), window.height()}},
-      .clearValueCount = (uint32_t) clearColourscontent.size(),
-      .pClearValues = clearColourscontent.data()
+      *contentRenderPass,
+      *contentFrameBuffer,
+      vk::Rect2D{{0, 0}, {window.width(), window.height()}},
+      (uint32_t) clearColourscontent.size(),
+      clearColourscontent.data()
     };
   }
 
@@ -956,11 +956,11 @@ int main() {
   
     // Begin rendering using the framebuffer and renderpass
     reflectionreflectorRpbi = vk::RenderPassBeginInfo{
-      .renderPass = *reflectionreflectorRenderPass,
-      .framebuffer = *reflectionreflectorFrameBuffer,
-      .renderArea = vk::Rect2D{{0, 0}, {window.width(), window.height()}},
-      .clearValueCount = (uint32_t) clearColoursreflectionreflector.size(),
-      .pClearValues = clearColoursreflectionreflector.data()
+      *reflectionreflectorRenderPass,
+      *reflectionreflectorFrameBuffer,
+      vk::Rect2D{{0, 0}, {window.width(), window.height()}},
+      (uint32_t) clearColoursreflectionreflector.size(),
+      clearColoursreflectionreflector.data()
     };
   }
 /*

--- a/examples/cybertruck/cybertruck.cpp
+++ b/examples/cybertruck/cybertruck.cpp
@@ -29,11 +29,11 @@ int main() {
   auto device = fw.device();
 
   vku::Window window{
-    .instance = fw.instance(),
-    .device = device,
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    device,
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;
@@ -125,12 +125,12 @@ int main() {
     // flip viewport to match opengl ( +x > Right, +y ^ UP, +z towards viewer from screen ), instead of vulkan default
     // also requires pipeline set with cullMode:BACK and frontFace:CounterClockWise
     auto viewport = vk::Viewport{
-      .x = 0.0f,                                     //Vulkan default:0
-      .y = static_cast<float>(window.height()),      //Vulkan default:0
-      .width = static_cast<float>(window.width()),   //Vulkan default:width
-      .height = -static_cast<float>(window.height()),//Vulkan default:height
-      .minDepth = 0.5f,                              //Vulkan default:0
-      .maxDepth = 1.0f                               //Vulkan default:1
+      0.0f,                                     //Vulkan default:0
+      static_cast<float>(window.height()),      //Vulkan default:0
+      static_cast<float>(window.width()),   //Vulkan default:width
+      -static_cast<float>(window.height()),//Vulkan default:height
+      0.5f,                              //Vulkan default:0
+      1.0f                               //Vulkan default:1
     };
   
     vku::PipelineMaker pm{window.width(), window.height()};

--- a/examples/dynamicUniformBuffer/dynamicUniformBuffer.cpp
+++ b/examples/dynamicUniformBuffer/dynamicUniformBuffer.cpp
@@ -35,11 +35,11 @@ int main() {
 
   // Create a window to draw into
   vku::Window window{
-    .instance = fw.instance(),
-    .device = device,
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    device,
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;

--- a/examples/fdtd2d/fdtd2d.cpp
+++ b/examples/fdtd2d/fdtd2d.cpp
@@ -22,11 +22,11 @@ int main() {
   vk::Device device = fw.device();
 
   vku::Window window{
-    .instance = fw.instance(),
-    .device = device,
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    device,
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;
@@ -35,12 +35,12 @@ int main() {
   window.dumpCaps(std::cout, fw.physicalDevice());
 
   auto viewport = vk::Viewport{
-    .x = 0.0f, 
-    .y = 0.0f,
-    .width = (float)window.width(),
-    .height = (float)window.height(),
-    .minDepth = 0.0f,
-    .maxDepth = 1.0f
+    0.0f, 
+    0.0f,
+    (float)window.width(),
+    (float)window.height(),
+    0.0f,
+    1.0f
   };
 
   ////////////////////////////////////////
@@ -425,17 +425,17 @@ int main() {
 
   // Begin rendering using the framebuffer and renderpass
   vk::RenderPassBeginInfo pass0Rpbi[]={{
-    .renderPass = *RenderPass0Ping,
-    .framebuffer = *FrameBufferPass0Ping,
-    .renderArea = vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
-    .clearValueCount = (uint32_t) clearColours.size(),
-    .pClearValues = clearColours.data()
+    *RenderPass0Ping,
+    *FrameBufferPass0Ping,
+    vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
+    (uint32_t) clearColours.size(),
+    clearColours.data()
   },{
-    .renderPass = *RenderPass0Pong,
-    .framebuffer = *FrameBufferPass0Pong,
-    .renderArea = vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
-    .clearValueCount = (uint32_t) clearColours.size(),
-    .pClearValues = clearColours.data()
+    *RenderPass0Pong,
+    *FrameBufferPass0Pong,
+    vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
+    (uint32_t) clearColours.size(),
+    clearColours.data()
   }};
 
   ////////////////////////////////////////
@@ -444,17 +444,17 @@ int main() {
   // sets the framebuffer and renderpass
  
   vk::RenderPassBeginInfo pass1Rpbi[]={{
-    .renderPass = *RenderPass1Ping,
-    .framebuffer = *FrameBufferPass1Ping,
-    .renderArea = vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
-    .clearValueCount = (uint32_t) clearColours.size(),
-    .pClearValues = clearColours.data()
+    *RenderPass1Ping,
+    *FrameBufferPass1Ping,
+    vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
+    (uint32_t) clearColours.size(),
+    clearColours.data()
   },{
-    .renderPass = *RenderPass1Pong,
-    .framebuffer = *FrameBufferPass1Pong,
-    .renderArea = vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
-    .clearValueCount = (uint32_t) clearColours.size(),
-    .pClearValues = clearColours.data()
+    *RenderPass1Pong,
+    *FrameBufferPass1Pong,
+    vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
+    (uint32_t) clearColours.size(),
+    clearColours.data()
   }};
 
   int iFrame = 0;

--- a/examples/fdtd2dUpml/fdtd2dUpml.cpp
+++ b/examples/fdtd2dUpml/fdtd2dUpml.cpp
@@ -61,11 +61,11 @@ int main() {
   vk::Device device = fw.device();
 
   vku::Window window{
-    .instance = fw.instance(),
-    .device = device,
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    device,
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;
@@ -74,12 +74,12 @@ int main() {
   window.dumpCaps(std::cout, fw.physicalDevice());
 
   auto viewport = vk::Viewport{
-    .x = 0.0f, 
-    .y = 0.0f,
-    .width = (float)window.width(),
-    .height = (float)window.height(),
-    .minDepth = 0.0f,
-    .maxDepth = 1.0f
+    0.0f, 
+    0.0f,
+    (float)window.width(),
+    (float)window.height(),
+    0.0f,
+    1.0f
   };
 
   ////////////////////////////////////////
@@ -516,17 +516,17 @@ int main() {
 
   // Begin rendering using the framebuffer and renderpass
   vk::RenderPassBeginInfo pass0Rpbi[]={{
-    .renderPass = *RenderPass0Ping,
-    .framebuffer = *FrameBufferPass0Ping,
-    .renderArea = vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
-    .clearValueCount = (uint32_t) clearColours.size(),
-    .pClearValues = clearColours.data()
+    *RenderPass0Ping,
+    *FrameBufferPass0Ping,
+    vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
+    (uint32_t) clearColours.size(),
+    clearColours.data()
   },{
-    .renderPass = *RenderPass0Pong,
-    .framebuffer = *FrameBufferPass0Pong,
-    .renderArea = vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
-    .clearValueCount = (uint32_t) clearColours.size(),
-    .pClearValues = clearColours.data()
+    *RenderPass0Pong,
+    *FrameBufferPass0Pong,
+    vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
+    (uint32_t) clearColours.size(),
+    clearColours.data()
   }};
 
   ////////////////////////////////////////
@@ -535,17 +535,17 @@ int main() {
   // sets the framebuffer and renderpass
  
   vk::RenderPassBeginInfo pass1Rpbi[]={{
-    .renderPass = *RenderPass1Ping,
-    .framebuffer = *FrameBufferPass1Ping,
-    .renderArea = vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
-    .clearValueCount = (uint32_t) clearColours.size(),
-    .pClearValues = clearColours.data()
+    *RenderPass1Ping,
+    *FrameBufferPass1Ping,
+    vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
+    (uint32_t) clearColours.size(),
+    clearColours.data()
   },{
-    .renderPass = *RenderPass1Pong,
-    .framebuffer = *FrameBufferPass1Pong,
-    .renderArea = vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
-    .clearValueCount = (uint32_t) clearColours.size(),
-    .pClearValues = clearColours.data()
+    *RenderPass1Pong,
+    *FrameBufferPass1Pong,
+    vk::Rect2D{{0, 0}, {fdtdDomainSize, fdtdDomainSize}},
+    (uint32_t) clearColours.size(),
+    clearColours.data()
   }};
 
   int iFrame = 0;

--- a/examples/flockaroo/flockaroo.cpp
+++ b/examples/flockaroo/flockaroo.cpp
@@ -24,11 +24,11 @@ int main() {
   vk::Device device = fw.device();
 
   vku::Window window{
-    .instance = fw.instance(),
-    .device = device,
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    device,
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;
@@ -37,12 +37,12 @@ int main() {
   window.dumpCaps(std::cout, fw.physicalDevice());
 
   auto viewport = vk::Viewport{
-    .x = 0.0f, 
-    .y = 0.0f,
-    .width = (float)window.width(),
-    .height = (float)window.height(),
-    .minDepth = 0.0f,
-    .maxDepth = 1.0f
+    0.0f, 
+    0.0f,
+    (float)window.width(),
+    (float)window.height(),
+    0.0f,
+    1.0f
   };
 
   ////////////////////////////////////////
@@ -344,17 +344,17 @@ int main() {
 
   // when index=0 write to iChannelPong, when index=1 write to iChannelPing   
   vk::RenderPassBeginInfo advectionRpbi[]={{
-    .renderPass = *advectionRenderPass,
-    .framebuffer = *advectionFrameBufferPong,
-    .renderArea = vk::Rect2D{{0, 0}, {advectionSize, advectionSize}},
-    .clearValueCount = (uint32_t) clearColours.size(),
-    .pClearValues = clearColours.data()
+    *advectionRenderPass,
+    *advectionFrameBufferPong,
+    vk::Rect2D{{0, 0}, {advectionSize, advectionSize}},
+    (uint32_t) clearColours.size(),
+    clearColours.data()
   },{
-    .renderPass = *advectionRenderPass,
-    .framebuffer = *advectionFrameBufferPing,
-    .renderArea = vk::Rect2D{{0, 0}, {advectionSize, advectionSize}},
-    .clearValueCount = (uint32_t) clearColours.size(),
-    .pClearValues = clearColours.data()
+    *advectionRenderPass,
+    *advectionFrameBufferPing,
+    vk::Rect2D{{0, 0}, {advectionSize, advectionSize}},
+    (uint32_t) clearColours.size(),
+    clearColours.data()
   }};
 
   int iFrame = 0;

--- a/examples/gumbo/gumbo.cpp
+++ b/examples/gumbo/gumbo.cpp
@@ -65,11 +65,11 @@ int main() {
 
   // Create a window to draw into
   vku::Window window{
-    .instance = fw.instance(),
-    .device = device,
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    device,
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;
@@ -162,12 +162,12 @@ int main() {
     // flip viewport to match opengl ( +x > Right, +y ^ UP, +z towards viewer from screen ), instead of vulkan default
     // also requires pipeline set with cullMode:BACK and frontFace:CounterClockWise
     auto viewport = vk::Viewport{
-      .x = 0.0f,                                     //Vulkan default:0
-      .y = static_cast<float>(window.height()),      //Vulkan default:0
-      .width = static_cast<float>(window.width()),   //Vulkan default:width
-      .height = -static_cast<float>(window.height()),//Vulkan default:height
-      .minDepth = 0.5f,                              //Vulkan default:0
-      .maxDepth = 1.0f                               //Vulkan default:1
+      0.0f,                                     //Vulkan default:0
+      static_cast<float>(window.height()),      //Vulkan default:0
+      static_cast<float>(window.width()),   //Vulkan default:width
+      -static_cast<float>(window.height()),//Vulkan default:height
+      0.5f,                              //Vulkan default:0
+      1.0f                               //Vulkan default:1
     };
 
     // Make a pipeline to use the vertex format and shaders.

--- a/examples/helloCompute/helloCompute.cpp
+++ b/examples/helloCompute/helloCompute.cpp
@@ -95,9 +95,9 @@ int main() {
   // Create Command Pool
   //
   vk::CommandPoolCreateInfo cpci{ 
-    .flags = vk::CommandPoolCreateFlagBits::eTransient 
+    vk::CommandPoolCreateFlagBits::eTransient 
            | vk::CommandPoolCreateFlagBits::eResetCommandBuffer, 
-    .queueFamilyIndex = fw.computeQueueFamilyIndex()
+    fw.computeQueueFamilyIndex()
   };
   auto commandPool = device.createCommandPoolUnique(cpci);
 

--- a/examples/helloGeometryShader/helloGeometryShader.cpp
+++ b/examples/helloGeometryShader/helloGeometryShader.cpp
@@ -33,11 +33,11 @@ int main() {
 
   // Create a window to draw into
   vku::Window window{
-    .instance = fw.instance(),
-    .device = device,
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    device,
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;

--- a/examples/helloTesselationShader/helloTesselationShader.cpp
+++ b/examples/helloTesselationShader/helloTesselationShader.cpp
@@ -33,11 +33,11 @@ int main() {
 
   // Create a window to draw into
   vku::Window window{
-    .instance = fw.instance(),
-    .device = device,
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    device,
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;

--- a/examples/helloTriangle/helloTriangle.cpp
+++ b/examples/helloTriangle/helloTriangle.cpp
@@ -33,11 +33,11 @@ int main() {
 
   // Create a window to draw into
   vku::Window window{
-    .instance = fw.instance(),
-    .device = device,
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    device,
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;

--- a/examples/perlinNoise/perlinNoise.cpp
+++ b/examples/perlinNoise/perlinNoise.cpp
@@ -246,12 +246,12 @@ int main() {
   // flip viewport to match opengl ( +x > Right, +y ^ UP, +z towards viewer from screen ), instead of vulkan default
   // also requires pipeline set with cullMode:BACK and frontFace:CounterClockWise
   auto viewport = vk::Viewport{
-    .x = 0.0f,                                     //Vulkan default:0
-    .y = static_cast<float>(window.height()),      //Vulkan default:0
-    .width = static_cast<float>(window.width()),   //Vulkan default:width
-    .height = -static_cast<float>(window.height()),//Vulkan default:height
-    .minDepth = 0.5f,                              //Vulkan default:0
-    .maxDepth = 1.0f                               //Vulkan default:1
+    0.0f,                                     //Vulkan default:0
+    static_cast<float>(window.height()),      //Vulkan default:0
+    static_cast<float>(window.width()),   //Vulkan default:width
+    -static_cast<float>(window.height()),//Vulkan default:height
+    0.5f,                              //Vulkan default:0
+    1.0f                               //Vulkan default:1
   };
 
   auto buildPipeline = [&]() {

--- a/examples/pushConstants/pushConstants.cpp
+++ b/examples/pushConstants/pushConstants.cpp
@@ -38,11 +38,11 @@ int main() {
 
   // Create a window to draw into
   vku::Window window{
-    .instance = fw.instance(),
-    .device = device,
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    device,
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;

--- a/examples/renderToCubemapByMultiview/renderToCubemapByMultiview.cpp
+++ b/examples/renderToCubemapByMultiview/renderToCubemapByMultiview.cpp
@@ -73,12 +73,12 @@ int main() {
   // flip viewport to match opengl ( +x > Right, +y ^ UP, +z towards viewer from screen ), instead of vulkan default
   // also requires pipeline set with cullMode:BACK and frontFace:CounterClockWise
   auto viewport = vk::Viewport{
-    .x = 0.0f,                                     //Vulkan default:0
-    .y = static_cast<float>(window.height()),      //Vulkan default:0
-    .width = static_cast<float>(window.width()),   //Vulkan default:width
-    .height = -static_cast<float>(window.height()),//Vulkan default:height
-    .minDepth = 0.5f,                              //Vulkan default:0
-    .maxDepth = 1.0f                               //Vulkan default:1
+    0.0f,                                     //Vulkan default:0
+    static_cast<float>(window.height()),      //Vulkan default:0
+    static_cast<float>(window.width()),   //Vulkan default:width
+    -static_cast<float>(window.height()),//Vulkan default:height
+    0.5f,                              //Vulkan default:0
+    1.0f                               //Vulkan default:1
   };
 
   // Vulkan clip space has inverted Y and half Z compared to OpenGL
@@ -391,11 +391,11 @@ int main() {
   
     // Begin rendering using the framebuffer and renderpass
     TriangleRpbi = vk::RenderPassBeginInfo{
-      .renderPass = *TriangleRenderPass,
-      .framebuffer = *TriangleFrameBuffer,
-      .renderArea = vk::Rect2D{{0, 0}, {window.width(), window.height()}},
-      .clearValueCount = (uint32_t) clearColors.size(),
-      .pClearValues = clearColors.data()
+      *TriangleRenderPass,
+      *TriangleFrameBuffer,
+      vk::Rect2D{{0, 0}, {window.width(), window.height()}},
+      (uint32_t) clearColors.size(),
+      clearColors.data()
     };
 
   }

--- a/examples/threaded/threaded.cpp
+++ b/examples/threaded/threaded.cpp
@@ -35,11 +35,11 @@ int main() {
 
   // Create a window to draw into
   vku::Window window{
-    .instance = fw.instance(),
-    .device = fw.device(),
-    .physicalDevice = fw.physicalDevice(),
-    .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-    .window = glfwwindow
+    fw.instance(),
+    fw.device(),
+    fw.physicalDevice(),
+    fw.graphicsQueueFamilyIndex(),
+    glfwwindow
   };
   if (!window.ok()) {
     std::cout << "Window creation failed" << std::endl;
@@ -110,8 +110,8 @@ int main() {
   std::cout << "Nthreads = " << Nthreads << std::endl;
 
   // allocate array of threads to be reused from frame to frame
-  std::thread v[Nthreads];
-
+  std::vector<std::thread> v( Nthreads );
+  
   // allocate command pools and secondary buffers, required to be separate pools per thread
   std::vector<vk::UniqueCommandPool> scp;
   std::vector<std::vector<vk::UniqueCommandBuffer>> scb;

--- a/examples/uniforms/uniforms.cpp
+++ b/examples/uniforms/uniforms.cpp
@@ -39,11 +39,11 @@ int main() {
 
     // Create a window to draw into
     vku::Window window{
-      .instance = fw.instance(),
-      .device = device,
-      .physicalDevice = fw.physicalDevice(),
-      .graphicsQueueFamilyIndex = fw.graphicsQueueFamilyIndex(),
-      .window = glfwwindow
+      fw.instance(),
+      device,
+      fw.physicalDevice(),
+      fw.graphicsQueueFamilyIndex(),
+      glfwwindow
     };
     if (!window.ok()) {
       std::cout << "Window creation failed" << std::endl;


### PR DESCRIPTION
I recently cloned Vookoo to try it out and learn a little bit of Vulkan, and I had issues compiling it in Visual Studio 2022 / MSVC v143. 

The first issue was that the examples were using designated initialisers; a C++20 feature, but their CMakeLists configured them to use C++11.
After fixing that, there were a couple of errors with using designated initialisers themselves (`error C7562: designated initialization can only be used to initialize aggregate class types`).
Finally, the multi-threaded example was doing the following:
```cpp
  // define number of threads
  const uint32_t Nthreads = std::thread::hardware_concurrency();
  std::cout << "Nthreads = " << Nthreads << std::endl;

  // allocate array of threads to be reused from frame to frame
  std::thread v[Nthreads];
```
Arrays like these are not allowed in MSVC, so I've changed it to `std::vector<std::thread> v( Nthreads );`. After successful compilation, I tested all the examples on my main PC with an RTX 3060 and they work without any runtime errors, except for tripping some Vulkan validation layers (primarily about [this one](https://vulkan.lunarg.com/doc/view/1.3.211.0/windows/1.3-extensions/vkspec.html#VUID-VkMappedMemoryRange-size-01389)), but my assumption is that this is "normal".