### PR TITLE
Fix compilation errors

### DIFF
--- a/examples/crystalLogo/crystalLogo.cpp
+++ b/examples/crystalLogo/crystalLogo.cpp
@@ -55,7 +55,13 @@ int main() {
 
   glfwSetCursorPosCallback(glfwwindow, mouse_callback);
 
-  vku::Framework fw{title};
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/cybertruck/cybertruck.cpp
+++ b/examples/cybertruck/cybertruck.cpp
@@ -19,7 +19,13 @@ int main() {
   auto *title = "CyberTruck";
   auto glfwwindow = glfwCreateWindow(1280, 720, title, nullptr, nullptr);
 
-  vku::Framework fw{title};
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/dynamicUniformBuffer/dynamicUniformBuffer.cpp
+++ b/examples/dynamicUniformBuffer/dynamicUniformBuffer.cpp
@@ -23,8 +23,14 @@ int main() {
   auto *title = "dynamicUniformBuffer";
   auto glfwwindow = glfwCreateWindow(800, 800, title, nullptr, nullptr);
 
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
   // Initialise the Vookoo demo framework.
-  vku::Framework fw{title};
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/fdtd2d/fdtd2d.cpp
+++ b/examples/fdtd2d/fdtd2d.cpp
@@ -12,7 +12,13 @@ int main() {
   const char *title = "fdtd2d";
   auto glfwwindow = glfwCreateWindow(1024, 1024, title, nullptr, nullptr);
 
-  vku::Framework fw{title};
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/fdtd2dUpml/fdtd2dUpml.cpp
+++ b/examples/fdtd2dUpml/fdtd2dUpml.cpp
@@ -51,7 +51,13 @@ int main() {
   const char *title = "fdtd2dUpml";
   auto glfwwindow = glfwCreateWindow(1024, 1024, title, nullptr, nullptr);
 
-  vku::Framework fw{title};
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/flockaroo/flockaroo.cpp
+++ b/examples/flockaroo/flockaroo.cpp
@@ -14,7 +14,13 @@ int main() {
   const char *title = "flockaroo";
   auto glfwwindow = glfwCreateWindow(1024, 1024, title, nullptr, nullptr);
 
-  vku::Framework fw{title};
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/gumbo/gumbo.cpp
+++ b/examples/gumbo/gumbo.cpp
@@ -53,8 +53,14 @@ int main() {
 
   glfwSetCursorPosCallback(glfwwindow, mouse_callback);
 
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
   // Initialise the Vookoo demo framework.
-  vku::Framework fw{title};
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/helloCompute/helloCompute.cpp
+++ b/examples/helloCompute/helloCompute.cpp
@@ -12,7 +12,13 @@
 #include <algorithm>
 
 int main() {
-  vku::Framework fw{"Hello compute"};
+
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/helloGeometryShader/helloGeometryShader.cpp
+++ b/examples/helloGeometryShader/helloGeometryShader.cpp
@@ -21,8 +21,14 @@ int main() {
   auto *title = "helloGeometryShader";
   auto glfwwindow = glfwCreateWindow(800, 800, title, nullptr, nullptr);
 
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
   // Initialise the Vookoo demo framework.
-  vku::Framework fw{title};
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/helloInstancing/helloInstancing.cpp
+++ b/examples/helloInstancing/helloInstancing.cpp
@@ -21,8 +21,14 @@ int main() {
   auto *title = "helloInstancing";
   auto glfwwindow = glfwCreateWindow(800, 800, title, nullptr, nullptr);
 
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
   // Initialise the Vookoo demo framework.
-  vku::Framework fw{title};
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/helloTesselationShader/helloTesselationShader.cpp
+++ b/examples/helloTesselationShader/helloTesselationShader.cpp
@@ -21,8 +21,14 @@ int main() {
   auto *title = "helloTesselationShader";
   auto glfwwindow = glfwCreateWindow(800, 800, title, nullptr, nullptr);
 
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
   // Initialise the Vookoo demo framework.
-  vku::Framework fw{title};
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/helloTriangle/helloTriangle.cpp
+++ b/examples/helloTriangle/helloTriangle.cpp
@@ -21,8 +21,14 @@ int main() {
   auto *title = "helloTriangle";
   auto glfwwindow = glfwCreateWindow(800, 800, title, nullptr, nullptr);
 
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
   // Initialise the Vookoo demo framework.
-  vku::Framework fw{title};
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/perlinNoise/perlinNoise.cpp
+++ b/examples/perlinNoise/perlinNoise.cpp
@@ -49,8 +49,14 @@ int main() {
 
   glfwSetCursorPosCallback(glfwwindow, mouse_callback);
 
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
   // Initialise the Vookoo demo framework.
-  vku::Framework fw{title};
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/pushConstants/pushConstants.cpp
+++ b/examples/pushConstants/pushConstants.cpp
@@ -26,8 +26,14 @@ int main() {
   const char *title = "pushConstants";
   auto glfwwindow = glfwCreateWindow(800, 800, title,  nullptr, nullptr);
 
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
   // Initialise the Vookoo demo framework.
-  vku::Framework fw{title};
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/renderToCubemapByMultiview/renderToCubemapByMultiview.cpp
+++ b/examples/renderToCubemapByMultiview/renderToCubemapByMultiview.cpp
@@ -49,8 +49,14 @@ int main() {
 
   glfwSetCursorPosCallback(glfwwindow, mouse_callback);
 
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
   // Initialise the Vookoo demo framework.
-  vku::Framework fw{title};
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/teapot/teapot.cpp
+++ b/examples/teapot/teapot.cpp
@@ -44,7 +44,13 @@ int main(int argc, char *argv[]) {
   auto glfwwindow = glfwCreateWindow(800, 600, title, nullptr, nullptr);
 
   {
-    vku::Framework fw{title};
+    // Initialize makers
+    vku::InstanceMaker im{};
+    im.defaultLayers();
+    vku::DeviceMaker dm{};
+    dm.defaultLayers();
+
+    vku::Framework fw{im, dm};
     if (!fw.ok()) {
       std::cout << "Framework creation failed" << std::endl;
       exit(1);

--- a/examples/texture/texture.cpp
+++ b/examples/texture/texture.cpp
@@ -11,7 +11,13 @@ int main() {
   const char *title = "texture";
   auto glfwwindow = glfwCreateWindow(800, 600, title, nullptr, nullptr);
 
-  vku::Framework fw{title};
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/threaded/threaded.cpp
+++ b/examples/threaded/threaded.cpp
@@ -26,8 +26,14 @@ int main() {
   const char *title = "threaded";
   auto glfwwindow = glfwCreateWindow(800, 800, title,  nullptr, nullptr);
 
+  // Initialize makers
+  vku::InstanceMaker im{};
+  im.defaultLayers();
+  vku::DeviceMaker dm{};
+  dm.defaultLayers();
+
   // Initialise the Vookoo demo framework.
-  vku::Framework fw{title};
+  vku::Framework fw{im, dm};
   if (!fw.ok()) {
     std::cout << "Framework creation failed" << std::endl;
     exit(1);

--- a/examples/uniforms/uniforms.cpp
+++ b/examples/uniforms/uniforms.cpp
@@ -27,8 +27,14 @@ int main() {
   auto glfwwindow = glfwCreateWindow(800, 800, title, nullptr, nullptr);
 
   {
+    // Initialize makers
+    vku::InstanceMaker im{};
+    im.defaultLayers();
+    vku::DeviceMaker dm{};
+    dm.defaultLayers();
+
     // Initialise the Vookoo demo framework.
-    vku::Framework fw{title};
+    vku::Framework fw{im, dm};
     if (!fw.ok()) {
       std::cout << "Framework creation failed" << std::endl;
       exit(1);

--- a/include/vku/vku.hpp
+++ b/include/vku/vku.hpp
@@ -953,7 +953,7 @@ public:
 	init();
   }
   
-  vk::UniquePipeline createUnique(const vk::Device &device,
+  auto createUnique(const vk::Device &device,
                             const vk::PipelineCache &pipelineCache,
                             const vk::PipelineLayout &pipelineLayout,
                             const vk::RenderPass &renderPass, bool defaultBlend=true) {
@@ -1288,7 +1288,7 @@ public:
   }
 
   /// Create a managed handle to a compute shader.
-  vk::UniquePipeline createUnique(vk::Device device, const vk::PipelineCache &pipelineCache, const vk::PipelineLayout &pipelineLayout) {
+  auto createUnique(vk::Device device, const vk::PipelineCache &pipelineCache, const vk::PipelineLayout &pipelineLayout) {
     vk::ComputePipelineCreateInfo pipelineInfo{};
 
     pipelineInfo.stage = stage_;

--- a/include/vku/vku.hpp
+++ b/include/vku/vku.hpp
@@ -953,7 +953,7 @@ public:
 	init();
   }
   
-  auto createUnique(const vk::Device &device,
+  vk::UniquePipeline createUnique(const vk::Device &device,
                             const vk::PipelineCache &pipelineCache,
                             const vk::PipelineLayout &pipelineLayout,
                             const vk::RenderPass &renderPass, bool defaultBlend=true) {
@@ -1004,7 +1004,9 @@ public:
     pipelineInfo.subpass = subpass_;
     pipelineInfo.pTessellationState = &tessellationState_;
 
-    return device.createGraphicsPipelineUnique(pipelineCache, pipelineInfo);
+    auto [result, pipeline] = device.createGraphicsPipelineUnique(pipelineCache, pipelineInfo);
+    // TODO check result for vk::Result::ePipelineCompileRequiredEXT
+    return std::move(pipeline);
   }
 
   /// Add a shader module to the pipeline.
@@ -1288,13 +1290,15 @@ public:
   }
 
   /// Create a managed handle to a compute shader.
-  auto createUnique(vk::Device device, const vk::PipelineCache &pipelineCache, const vk::PipelineLayout &pipelineLayout) {
+  vk::UniquePipeline createUnique(vk::Device device, const vk::PipelineCache &pipelineCache, const vk::PipelineLayout &pipelineLayout) {
     vk::ComputePipelineCreateInfo pipelineInfo{};
 
     pipelineInfo.stage = stage_;
     pipelineInfo.layout = pipelineLayout;
 
-    return device.createComputePipelineUnique(pipelineCache, pipelineInfo);
+    auto [ result, pipeline ] = device.createComputePipelineUnique(pipelineCache, pipelineInfo);
+    // TODO check result for vk::Result::ePipelineCompileRequiredEXT
+    return std::move(pipeline);
   }
 private:
   vk::PipelineShaderStageCreateInfo stage_;


### PR DESCRIPTION
This PR fixes the compilaton errors with current Vulkan-Hpp headers, as well as the compilation errors in the examples where the `vku::Framework` constructor changed in `vku_framework.hpp` but was not updated in the examples accordingly.

This also fixes #48 .
